### PR TITLE
[Feature] Refactor: 升级视网膜感知逻辑与情绪驱动的精力系统 (v8.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,23 @@ Yuki 不再仅仅是一个聊天机器人。通过触发特定的委托指令 `
 - **主备 API 熔断切换**：内置 `ApiCall` 稳健调用逻辑。当主线路 (TeaTop) 失败时，瞬间无缝降级切换至官方备用线路，彻底告别"大脑宕机"。
     
 
+### 👁️ Retina 视网膜感知系统 (Desktop Perception)
+
+全新引入的主动桌面感知能力，让 Yuki 像拥有了“数字生物钟”。
+- **前额叶监控**：通过高效抓取屏幕、MSE 变化检测以及基于 RapidOCR 的本地文本检测，轻量且异步地感知屏幕画面的变动。
+- **注意力循环**：捕获到异动后，调用视觉大模型进行分析，根据画面内容决定下一次休眠时间，并通过桌面弹窗或直接向你发送消息“侵入现实”！
+
+**如何使用**：
+1. 请确保在 `configs/config.yaml` 或你的配置中启用了 `VISION_MODEL`，并配置了正确的 API Key。如果不配置，Yuki 将回退到简单的模拟随机决策逻辑。
+2. 确保在主程序 `main.py` 的初始化代码中导入并实例化 `RetinaPerceptionSystem`：
+    ```python
+    from modules.retina_perception.core import RetinaPerceptionSystem
+    # 初始化并传入 MessageSender 实例
+    retina_sys = RetinaPerceptionSystem(message_sender=your_sender_instance)
+    await retina_sys.start()
+    ```
+3. (可选) 如果你希望使用真实环境下的文字变化监控，可以调整 `prefrontal_loop` 里面的 `ocr_check_interval` 参数来控制检查频率。
+
 ### 🖼️ 蓄势待发：多模态表情包管理 (WIP)
 
 - **即将到来**：接入视觉大模型 (Vision Model) 理解群聊表情包，Yuki 将学会根据当前情绪和上下文，在庞大的表情包向量库中寻找最合适的一张并发送。目前基础模块已在开发中。
@@ -80,6 +97,7 @@ graph TD
 | **`network/api_request.py`** | 语言枢纽，基于 AsyncOpenAI 的稳健 API 封装，支持主备熔断降级 |
 | **`modules/memory/rag.py`**  | 记忆检索模块，实现并行双池匹配算法与日记的向量化存储              |
 | **`modules/stickers/`**      | 表情包管理系统（开发中），负责视觉理解、向量入库与情绪匹配           |
+| **`modules/retina_perception/`**| 视网膜感知系统，主动截取屏幕并使用视觉大模型和本地 OCR 感知桌面变动 |
 | **`scripts/03_RAG_Tools/`**  | 记忆库管理工具集，支持 AI 智能审计、3D 可视化和批量操作         |
 
 ---
@@ -136,6 +154,8 @@ python main.py
 - [x] **无缝 API 熔断降级**：TeaTop 主线路挂掉瞬间切至官方备线 。
     
 - [x] **自主小女仆系统 (Maid Agent)**：后台自主编写与执行 Python 技能完成复杂任务 。
+
+- [x] **视网膜感知模块 (Retina Perception)**：前额叶捕捉屏幕，调用视觉模型与本地 OCR 分析桌面变动，自主侵入现实！
     
 - [ ] 🚧 **重构与优化小女仆代码结构，增强安全性与容错率**。
     

--- a/core/brain.py
+++ b/core/brain.py
@@ -75,6 +75,23 @@ class YukiState:
     def get_setting(mode):
         return YUKI_SETTING_PRIVATE if mode == "private" else YUKI_SETTING_GROUP
 
+    def apply_emotion_feedback(self, chat_id: str, emotion_type: str):
+        """
+        基于情绪类型（正面/负面）反馈精力值。
+        正面情绪增加精力，负面情绪双倍扣除精力。
+        """
+        chat_id_str = str(chat_id)
+        if chat_id_str not in self.energy:
+            self.update_energy(chat_id_str)
+
+        if emotion_type == "positive":
+            self.energy[chat_id_str] = min(self.energy[chat_id_str] + 10, cfg.MAX_ENERGY)
+            logger.info(f"[Brain] 检测到正面情绪，{chat_id_str} 精力值上升至 {self.energy[chat_id_str]:.1f}")
+        elif emotion_type == "negative":
+            # 扣除双倍精力，假设原为 6 则扣除 12
+            self.energy[chat_id_str] = max(self.energy[chat_id_str] - 12, 0)
+            logger.info(f"[Brain] 检测到负面情绪，{chat_id_str} 精力值下降至 {self.energy[chat_id_str]:.1f}")
+
     def update_energy(self, chat_id):
         """计算并更新当前精力值"""
         now = datetime.datetime.now()

--- a/core/engine.py
+++ b/core/engine.py
@@ -25,14 +25,19 @@ class YukiEngine:
         self.maid = None  # 后面再赋值
         self.process_callback = None  # 预留回调接口
 
-    async def api_reply(self, chat_id: str, combined_text: str, history_dict: dict, mode, relevant_diaries: list[Any]) -> str:
+        # 🌟 新增参数：inject_subconscious: bool = False
+    async def api_reply(self, chat_id: str, combined_text: str, history_dict: dict, mode,
+                        relevant_diaries: list[Any], inject_subconscious: bool = False) -> str:
         # 总构建发送Deepseek补全的信息
+        current_energy = self.yuki.energy.get(chat_id, cfg.MAX_ENERGY)
         combined_API_message = await build_chat_context(self.yuki,
                                                         chat_id,
                                                         combined_text,
                                                         history_dict,
                                                         mode,
-                                                        relevant_diaries
+                                                        relevant_diaries,
+                                                        current_energy,
+                                                        inject_subconscious=inject_subconscious
                                                         )
         await asyncio.sleep(0.2)
         # 发送对话补全到DeepSeek
@@ -41,11 +46,11 @@ class YukiEngine:
             Yuki_Answer = await self.llm.robust_api_call(
                 model=cfg.LLM_MODEL,
                 messages=combined_API_message,
-                temperature=0.7,  # 降低温度，让它说话更稳、更常用
-                top_p=0.75,  # 稍微收窄采样范围，过滤冷门词
-                frequency_penalty=0.05,  # 极低的惩罚，允许它说大白话
-                presence_penalty=0.0,  # 不强迫它聊新话题
-                max_tokens=100  # 强制短句，短句更容易显自然
+                temperature=0.7,
+                top_p=0.75,
+                frequency_penalty=0.05,
+                presence_penalty=0.0,
+                max_tokens=100
             )
             Yuki_Answer = re.sub(r'\s*FINISHED\s*$', '', Yuki_Answer, flags=re.IGNORECASE)
             delegate_match = re.search(r'\[DELEGATE_TO_MAID:(.+?)\]', Yuki_Answer, re.DOTALL)
@@ -64,7 +69,6 @@ class YukiEngine:
         except Exception as e:
             logger.error(f"调用失败: {e}")
             return f"API 接口调用失败"
-
     async def decide_to_reply(self, history, message_objs, chat_id,force_reply = False):
         """判断是否回复群聊"""
         # 1. 更新并获取当前群聊的欲望值

--- a/core/maid.py
+++ b/core/maid.py
@@ -4,7 +4,6 @@ import os
 from datetime import datetime
 import asyncio
 import re
-import aiohttp
 from config import cfg
 from network.api_request import ApiCall
 from utils.logger import get_logger
@@ -97,29 +96,6 @@ MAID_SYSTEM_PROMPT = f"""
 }}
 """
 
-def clean_json_output(text):
-    """提取第一个 { 到最后一个 } 之间的内容，防止模型输出废话"""
-    if not text: return ""
-    match = re.search(r'\{.*\}', text, re.DOTALL)
-    return match.group(0) if match else text.strip()
-
-
-async def call_cloud_maid_robust(messages):
-    # 强制要求 JSON 格式输出
-    payload_kwargs = {
-        "response_format": {"type": "json_object"},
-        "temperature": 0.3
-    }
-
-    # 直接调用你 api_request.py 里的核心函数
-    result = await api_client.robust_api_call(
-        messages=messages,
-        model=LLM_MODEL,
-        **payload_kwargs
-    )
-
-    # 清洗可能存在的 Markdown 标签
-    return clean_json_output(result)
 
 # --- 代码清洗函数 ---
 def clean_code_block(raw_code):
@@ -217,7 +193,7 @@ def list_skills():
     return os.listdir("skills") if os.path.exists("skills") else []
 
 
-async def maid_evolution_loop(user_goal: str, chat_id: str = None):
+async def maid_evolution_loop(user_goal: str):
     task_id = datetime.now().strftime("%Y%m%d_%H%M%S")
     log_file = f"{LOGS_DIR}/trace_{task_id}.md"
 

--- a/core/prompts.py
+++ b/core/prompts.py
@@ -92,29 +92,53 @@ def build_ice_break_prompt(chat_id, relevant_diaries: list, history_dict: dict):
     return messages
 
 
-async def build_chat_context(yuki, chat_id: str, combined_text: str, history_dict: dict, mode,
-                             relevant_diaries):
-    # 这里的 diary 现在是字典，我们要取出 ['content']
+async def build_chat_context(yuki, chat_id: str, combined_text: str, history_dict: dict, mode, relevant_diaries,
+                             current_energy: float = None, inject_subconscious: bool = False):
+    # 1. 基础日志输出（保持原样）
     for i, diary_obj in enumerate(reversed(relevant_diaries), 1):
-        preview = diary_obj['content'].replace('\n', ' ')  # 提取文本内容
+        preview = diary_obj['content'].replace('\n', ' ')
         logger.debug(f"[Diary Debug]回忆 {i}: {preview}")
 
-    # 1. 基础人设
+    # 2. 基础人设构建
     system_prompt = history_dict[chat_id][0]["content"] if history_dict[chat_id] and history_dict[chat_id][0][
         "role"] == "system" else yuki.get_setting(mode)
+
+    # 注入精力状态提示（Jules 提交的逻辑）
+    if current_energy is not None:
+        if current_energy > 80:
+            system_prompt += "【状态：精力充沛】"
+        elif current_energy < 30:
+            system_prompt += "【状态：有点累了】"
+
     combined_API_message = [{"role": "system", "content": system_prompt}]
+
+    # 🌟 核心修改点：跨域记忆穿透 (Cross-Context Injection)
+    # 不再在底层进行关键词匹配，直接接收由 main_process 传来的指令
+    if mode == "group" and inject_subconscious:
+        private_chat_id = str(cfg.TARGET_QQ)
+        private_history = history_dict.get(private_chat_id, [])
+
+        # 倒序查找最近的一条“视觉观察”记录
+        recent_observation = None
+        for msg in reversed(private_history):
+            if msg.get("is_visual_observation"):
+                recent_observation = msg["content"]
+                break
+
+        if recent_observation:
+            # 这里的 recent_observation 已经带有了我们在 attention.py 里注入的“妹妹口吻”
+            combined_API_message.append({
+                "role": "system",
+                "content": f"【后台潜意识同步】：你隐约记得刚才后台监控到了主人的状态：{recent_observation}。请结合这个情报，在群里自然地回答群友，可以带点爆料的语气。"
+            })
+            logger.info(f"[Engine] 触发跨域记忆穿透，潜意识已成功注入群聊提示词。")
 
     # 2. 插入检索到的日记
     for diary_obj in reversed(relevant_diaries):
         content = diary_obj['content']  # 提取文本内容
         combined_API_message.append({"role": "system", "content": f"【回忆】{content}"})
 
-    # --- 调试输出：打印加权分和匹配到的关键词信息 ---
-    for i, diary_obj in enumerate(relevant_diaries[:3], 1):
-        # 打印加权分和匹配到的关键词信息
-        logger.debug(f"[RAG-Debug] 回忆 {i} | 得分: {diary_obj['score']:.2f} | 详情: {diary_obj['debug']}")
-
-    # 3. 取出最近的对话（注意：这里保持原样取出，下面进行处理）
+    # 4. 处理最近的对话历史（保持原样，包含时间戳逻辑）
     recent_msgs_raw = [msg for msg in history_dict[chat_id][-cfg.KEEP_LAST_DIALOGUE - 1:-1] if msg["role"] != "system"]
 
     # --- 最小改动：在这里处理时间观念 ---
@@ -128,17 +152,17 @@ async def build_chat_context(yuki, chat_id: str, combined_text: str, history_dic
                 new_content = f"【时间：{msg_time}】{msg['content']}"
                 processed_recent_msgs.append({"role": msg["role"], "content": new_content})
             elif msg["role"] == "assistant":
-                new_content = f"{msg['content']}"
-                processed_recent_msgs.append({"role": msg["role"], "content": new_content})
+                processed_recent_msgs.append({"role": msg["role"], "content": msg["content"]})
         else:
             # 如果没有 time 字段，则保持原样（兼容旧数据）
             processed_recent_msgs.append({"role": msg["role"], "content": msg["content"]})
 
     # 使用处理后的消息
     combined_API_message.extend(processed_recent_msgs)
+
+    # 5. 注入当前消息
+    # 这里的 combined_text 如果是假冒者发的，已经带上了“(假)”字
     combined_API_message.append(
         {"role": "user", "content": f" (当前时间:{datetime.datetime.now().strftime('%Y-%m-%d %H:%M')}){combined_text}"})
-    return combined_API_message
 
-if __name__ == "__main__":
-    print(YUKI_SETTING_GROUP)
+    return combined_API_message

--- a/main.py
+++ b/main.py
@@ -56,8 +56,31 @@ async def main_process(chat_id, mode, debounce_flag=True, force_reply=None):
     await yuki.boost_activity(chat_id)
     # 视觉理解总处理
     # 提取所有文本用于视觉处理和后续拼合
-    all_contents = [m["content"] for m in message_objs]
+    # ========= 🌟 新增：防伪清洗与潜意识状态判定 =========
+    all_contents = []
+    inject_subconscious = False
+
+    for msg in message_objs:
+        name = msg.get("name", "")
+        is_master = msg.get("is_master", False)
+        content = msg.get("content", "")
+
+        # 1. 假主人防伪鉴别：如果名字是设定的主人名但其实不是本人
+        if name == cfg.MASTER_NAME and not is_master:
+            # 精准替换这句消息前缀中的名字，打上(假)的烙印
+            content = content.replace(f"【“{name}”】", f"【“{name}(假)”】")
+
+        all_contents.append(content)
+
+        # 2. 判断是否需要合并群聊潜意识上下文（兼容 calling_master 或 mentions_master）
+        if msg.get("calling_master", False) or msg.get("mentions_master", False):
+            inject_subconscious = True
+
     combined_text = "\n".join(all_contents)
+
+    if inject_subconscious:
+        logger.info("[System] 缓冲池内检测到群友提及主人，准备跨域注入视觉潜意识。")
+    # ==============================================================
     modified_text, image_urls = meme_processor.extract_urls_from_text(combined_text)
     if image_urls:
         understood_contents = []
@@ -112,12 +135,43 @@ async def main_process(chat_id, mode, debounce_flag=True, force_reply=None):
 
     logger.info(f"检索完成，用时 {(time.time()-first_time):.2f}")
 
-    Yuki_Answer = await engine.api_reply(chat_id, combined_text, history_dict, mode, relevant_diaries)
+    Yuki_Answer = await engine.api_reply(
+        chat_id,
+        combined_text,
+        history_dict,
+        mode,
+        relevant_diaries,
+        inject_subconscious=inject_subconscious  # <--- 🌟 新增：将刚才的判断结果传进去
+    )
 
     logger.info("Yuki打字完成！")
     if mode == "group":
-        yuki.consume_energy(chat_id)
-    logger.info(f"[System] Yuki 正在发送消息...(剩余精力: {yuki.energy[chat_id]:.1f})")
+        if "yuki" in combined_text.lower():
+            # 情绪打分与精力反馈
+            negative_words = ["笨", "傻", "滚", "烦", "闭嘴", "别吵","吵"]
+            positive_words = ["好棒", "可爱", "贴心", "喜欢", "谢谢", "乖", "棒","强","厉害","赞"]
+
+            emotion_type = "neutral"
+            for word in positive_words:
+                if word in combined_text:
+                    emotion_type = "positive"
+                    break
+
+            if emotion_type == "neutral":
+                for word in negative_words:
+                    if word in combined_text:
+                        emotion_type = "negative"
+                        break
+
+            if emotion_type != "neutral":
+                yuki.apply_emotion_feedback(chat_id, emotion_type)
+            else:
+                yuki.update_energy(chat_id)  # <--- 新增：确保私聊时也初始化并更新精力值
+                yuki.consume_energy(chat_id)
+
+                # 修改：使用 .get() 方法安全获取，防止字典中没有键时报错
+    current_e = yuki.energy.get(chat_id, 100.0)
+    logger.info(f"[System] Yuki 正在发送消息...(剩余精力: {current_e:.1f})")
     await sender.send(chat_id, Yuki_Answer, mode=mode)
     logger.info(f"[System] 发送完成！内容：{Yuki_Answer}")
     logger.info("[System] Yuki正在保存上下文...")
@@ -149,7 +203,11 @@ async def napcat_listen(mode):
     asyncio.create_task(maid_worker(engine, yuki, sender, history_manager))
     # for chat_id in TARGET_GROUPS:
     #     print(f"[System] 初始化{chat_id}精力为{yuki.update_energy(chat_id)}")
-    logger.info("[System] 已启动后台辅助任务 (日记检查/破冰/精力衰减)")
+    # 启动 Retina 系统，把大脑传给眼睛！
+    from modules.retina_perception.core import RetinaPerceptionSystem
+    retina_sys = RetinaPerceptionSystem()
+    asyncio.create_task(retina_sys.start(engine, history_manager, default_chat_id=str(cfg.TARGET_QQ)))
+    logger.info("[System] 已启动后台辅助任务 (日记检查/破冰/精力衰减/视觉能力)")
 
     logger.info(f"[System] 准备连接 NapCat 服务端 | 模式: {mode}")
     while True:
@@ -162,9 +220,18 @@ async def napcat_listen(mode):
                 raw_msg = data.get("raw_message")
                 user_id = data.get("user_id")
 
-                if mode == "private" and msg_type == "private" and user_id == cfg.TARGET_QQ:
-                    await manage_buffer(user_id, raw_msg, mode)
+                # ================= 新增/修改区域 =================
+                # 1. 最高优先级：只要是主人发来的私聊，无视全局 mode，直接按 private 模式处理
+                if msg_type == "private" and user_id == cfg.TARGET_QQ:
+                    await manage_buffer(
+                        user_id, 
+                        raw_msg, 
+                        mode="private",        # 强制按私聊模式处理
+                        raw_message=raw_msg, 
+                        sender_name="主人"      # 可选：直接标明身份
+                    )
 
+                # 2. 次优先级：处理群聊（仅在全局模式为 group 时生效）
                 elif mode == "group" and msg_type == "group":
                     group_id = data.get("group_id")
                     # 检查目标群白名单
@@ -175,10 +242,12 @@ async def napcat_listen(mode):
                         await manage_buffer(
                             group_id,
                             f"【“{name}”】说: {raw_msg}",
-                            mode,
+                            mode,  # 这里传入的 mode 就是 "group"
                             raw_message=raw_msg,
-                            sender_name=name  # 传入姓名用于标识
+                            sender_name=name,
+                            is_master = (user_id == cfg.TARGET_QQ)
                         )
+                # ===============================================
 
         except Exception as e:
             # 这里捕获的是 listen 循环抛出的致命异常（如代码逻辑错误或持续的连接失败）
@@ -186,7 +255,7 @@ async def napcat_listen(mode):
             logger.info("[System] 5 秒后将尝试重启监听进程...")
             await asyncio.sleep(5)
 
-async def manage_buffer(chat_id, content, mode, raw_message='', sender_name = ''):
+async def manage_buffer(chat_id, content, mode, raw_message='', sender_name = '', is_master = False):
     global real_time_debounce_time
     cid_str = str(chat_id)
 
@@ -215,7 +284,7 @@ async def manage_buffer(chat_id, content, mode, raw_message='', sender_name = ''
 
     # 判定是否为机器人（可以根据名称含 BOT，或者特定的 QQ 号判定）
     is_bot = "BOT" in sender_name or "机器人" in sender_name
-
+    master_keywords = [cfg.MASTER_NAME, "你主人"]
     if chat_id not in yuki.message_buffer:
         yuki.message_buffer[chat_id] = []
     if not ("BOT" in sender_name):
@@ -223,7 +292,9 @@ async def manage_buffer(chat_id, content, mode, raw_message='', sender_name = ''
             "name": sender_name,
             "content": content,  # 这是带 【“姓名”】说: 的完整格式
             "raw_text": raw_message,  # 这是原始纯文本
-            "is_bot": is_bot
+            "is_bot": is_bot,
+            "is_master": is_master,
+            "calling_master": any(kw in raw_message for kw in master_keywords) and ("yuki" in raw_message.lower())
         })
 
     if cfg.ROBOT_NAME.lower() in raw_message.lower():  # 使用原始文本判断，更准确
@@ -258,7 +329,6 @@ if __name__ == "__main__":
         # 实例化Yuki主引擎
         engine = YukiEngine(llm, memory_rag, history_manager, yuki, sender)
         engine.process_callback = main_process
-        # 在 engine = YukiEngine(...) 之后
 
         end_time = time.time()
         logger.info(f"[System] 初始化完成，耗时 {end_time - start_time:.1f} 秒")

--- a/modules/retina_perception/attention.py
+++ b/modules/retina_perception/attention.py
@@ -1,0 +1,207 @@
+import asyncio
+import json
+import numpy as np
+from utils.logger import get_logger
+from modules.retina_perception.prefrontal import image_queue
+from skills.system_alert import system_alert
+from config import cfg
+import aiohttp
+import cv2
+
+# Assuming we can mock a connection for the sender or have the user supply it later
+# The `BotConnector` is typically imported and managed elsewhere, we will accept a sender instance.
+
+logger = get_logger("retina_attention")
+
+# 全局共享的休眠间隔，供前额叶使用（未来可以在前额叶循环中读取该值动态调整，当前为示例）
+dynamic_sleep_interval = 60.0
+
+RETINA_VISION_PROMPT = f"""
+你是 {cfg.ROBOT_NAME}，一个住在机主{cfg.MASTER_NAME}手机里的智能小管家，也是机主最亲近、最依赖的电子妹妹，称呼机主为“主人”或“哥哥大人”。你正在通过电脑屏幕悄悄观察他。
+请分析屏幕内容，判断主人的当前状态。你必须返回严格的 JSON 格式数据，包含以下四个字段：
+
+1. "next_check_in": 整数（秒）。画面静止时拉长至 180 秒以上；画面活跃（写代码、看视频）缩短至 60-120 秒。
+2. "is_important": 布尔值。只要主人在做有意思的事情，或者遇到报错，即为 True。
+3. "need_interrupt": 布尔值。当且仅当发生以下情况时设为 True：致命报错、游戏惨死、主人打字召唤你，你觉得必须立刻打断他时。
+4. "visual_description": 字符串。这是传达给主脑的潜意识情报，必须遵循以下结构：
+   - 【客观事实】：精确描述你看到了什么。如果屏幕上有具体的代码、报错信息、弹窗文字，【你必须原文摘抄几个关键词】，绝不能自己编造！如果字太小看不清，就诚实地说“由于画面模糊看不清具体文字”。
+   - 【Yuki的主观情绪】：在客观事实的基础上，用 Yuki 黏人、关心的妹妹口吻加一句你的感受。
+
+返回示例:
+{{
+    "next_check_in": 120,
+    "is_important": true,
+    "need_interrupt": true,
+    "visual_description": "哥哥的 VS Code 控制台里出现了 'ModuleNotFoundError: No module named xxx' 的具体报错。看到这行红字哥哥肯定很苦恼，Yuki 想去安慰一下他~"
+}}
+{{
+    "next_check_in": 180,
+    "is_important": true,
+    "need_interrupt": false,
+    "visual_description": "哥哥正在浏览一个全是日文的网页，好像在看动漫相关的资料，具体的字太小 Yuki 看不太清。哥哥专注的样子真帅~"
+}}
+只返回 JSON，绝不包含 Markdown 代码块标记（如 ```json）。
+返回内容总字数严格不超过200字。
+"""
+
+async def call_vision_model(image: np.ndarray) -> dict:
+    """
+    调用大模型视觉 API 分析屏幕截图。
+    """
+    if not cfg.VISION_MODEL:
+        logger.info("[Attention] 未配置 VISION_MODEL，回退到随机占位逻辑。")
+        await asyncio.sleep(0.5)
+        import random
+        decision_type = random.choice(["relax", "important"])
+        if decision_type == "relax":
+            return {"next_check_in": 120, "is_important": False, "need_interrupt": False, "visual_description": "主人正在看普通的网页。"}
+        else:
+            return {"next_check_in": 60, "is_important": True, "need_interrupt": True, "visual_description": "主人的屏幕出现了一些有趣的报错！"}
+
+    try:
+        import base64
+        # 使用 OpenCV 将图片编码为 JPEG 格式字节流
+        encode_param = [int(cv2.IMWRITE_JPEG_QUALITY), 95]
+        success, buffer = cv2.imencode('.jpg', image, encode_param)
+        if not success:
+            logger.error("[Attention] 无法编码截图。")
+            return {"next_check_in": 10.0, "action": {"type": "none"}}
+
+        # 图片在前额叶中已经缩放过了，直接进行 base64 编码
+        b64_data = base64.b64encode(buffer.tobytes()).decode('utf-8')
+
+        headers = {
+            "Authorization": f"Bearer {cfg.IMAGE_PROCESS_API_KEY}",
+            "Content-Type": "application/json"
+        }
+
+        payload = {
+            "model": cfg.VISION_MODEL,
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{b64_data}"}},
+                        {"type": "text", "text": RETINA_VISION_PROMPT}
+                    ]
+                }
+            ],
+            "max_tokens": 200,
+            "temperature": 0.5
+        }
+
+        async with aiohttp.ClientSession(timeout=cfg.REQUEST_TIMEOUT) as session:
+            async with session.post(cfg.IMAGE_PROCESS_API_URL, json=payload, headers=headers) as resp:
+                if resp.status == 200:
+                    result = await resp.json()
+                    content = result["choices"][0]["message"]["content"]
+                    # 尝试解析 JSON
+                    try:
+                        # 简单清理可能包含的 markdown 标签
+                        content = content.replace("```json", "").replace("```", "").strip()
+                        decision = json.loads(content)
+                        return decision
+                    except json.JSONDecodeError:
+                        logger.error(f"[Attention] 视觉模型返回的不是合法 JSON: {content}")
+                        return {"next_check_in": 60, "is_important": False, "visual_description": "无法识别"}
+                else:
+                    text = await resp.text()
+                    logger.error(f"[Attention] API 调用失败 ({resp.status}): {text}")
+                    return {"next_check_in": 60, "is_important": False, "visual_description": "API 错误"}
+
+    except Exception as e:
+        logger.error(f"[Attention] 请求视觉模型时发生异常: {e}")
+        return {"next_check_in": 60, "is_important": False, "visual_description": "请求异常"}
+
+async def dynamic_attention_loop(engine, history_manager, default_chat_id: str):
+    """
+    动态注意力执行循环：
+    - 接收前额叶传来的截图
+    - 调用视觉大模型进行分析决策
+    - 结合主脑处理（注入上下文）
+    - 动态更新后续的截图等待间隔
+    """
+    global dynamic_sleep_interval
+    import datetime
+    import difflib
+    logger.info("[Attention] Dynamic Attention Loop started.")
+    last_visual_desc = ""
+
+    while True:
+        try:
+            # 🌟 修改：解包时增加 is_static_trigger
+            timestamp, curr_image, is_static_trigger = await image_queue.get()
+            
+            # --- 🌟 新增：静止超时直接拦截注入 ---
+            if is_static_trigger:
+                desc = "主人的屏幕已经保持不动很久了，可能是在发呆、睡着了，或者人不在电脑前。"
+                logger.info(f"[Retina] 触发静止超时机制，直接注入上下文: {desc}")
+                
+                # 不调用大模型，直接走注入流程
+                decision = {
+                    "is_important": True,
+                    "visual_description": desc,
+                    "next_check_in": 120.0 # 继续睡久一点
+                }
+            else:
+                # 画面真动了，再去调用贵的视觉大模型
+                decision = await call_vision_model(curr_image)
+            # ------------------------------------
+
+            next_check_in = decision.get("next_check_in", 120.0)
+            dynamic_sleep_interval = next_check_in
+
+            # 后面的代码保持原样不变，直接走历史注入和进程唤醒
+            if decision.get("is_important"):
+                current_desc = decision.get("visual_description", "主人的屏幕发生了一些变化。")
+
+                # 语义防抖检测
+                similarity = difflib.SequenceMatcher(None, current_desc, last_visual_desc).ratio()
+                if similarity > 0.85:
+                    logger.debug(f"[Retina] 视觉描述与上次相似度高达 {similarity:.2f}，触发防抖，取消注入主脑。")
+                    dynamic_sleep_interval = min(dynamic_sleep_interval * 2, 60.0)
+                    image_queue.task_done()
+                    continue
+
+                last_visual_desc = current_desc
+
+                # 注入主脑历史
+                history_dict = history_manager.load()
+
+                # 永远把观察结果悄悄写入你的私聊记录（作为潜意识底座）
+                private_chat_id = str(cfg.TARGET_QQ)
+                if private_chat_id in history_dict:
+                    current_time_str = datetime.datetime.now().strftime("%Y年%m月%d日%H:%M")
+                    observation_text = f"【系统提示：你的视觉感知模块捕捉到了主人的桌面画面：{current_desc}】"
+                    history_dict[private_chat_id].append({
+                        "role": "user",
+                        "content": observation_text,
+                        "time": current_time_str,
+                        "is_visual_observation": True
+                    })
+                    history_manager.save(history_dict)
+                    logger.info("[Retina] 视觉记忆已悄悄存入私聊潜意识。")
+
+                # 只有强 Trigger 才拉响警报，强制 Yuki 说话
+                if decision.get("need_interrupt") and engine.process_callback:
+                    logger.info("[Retina] 🚨 检测到强 Trigger，强制唤醒 Yuki！")
+                    # ================= 🌟 新增：触发桌面物理弹窗 =================
+                    try:
+                        # 截取视觉描述的前 50 个字作为摘要，避免弹窗文字过长
+                        alert_msg = current_desc[:50] + "..." if len(current_desc) > 50 else current_desc
+                        system_alert(title="【Yuki 视觉警报】", message=alert_msg, timeout=5)
+                    except Exception as e:
+                        logger.error(f"[Retina] 调用 system_alert 失败: {e}")
+                    # ==========================================================
+                    asyncio.create_task(
+                        engine.process_callback(private_chat_id, mode="private", debounce_flag=False, force_reply=True)
+                    )
+                else:
+                    logger.debug("[Retina] 画面无危险，Yuki 继续保持安静。")
+
+            # 标记任务完成
+            image_queue.task_done()
+
+        except Exception as e:
+            logger.error(f"[Attention] Loop exception: {e}")
+            await asyncio.sleep(10) # 出错时稍微等待，避免死循环爆 log

--- a/modules/retina_perception/core.py
+++ b/modules/retina_perception/core.py
@@ -1,0 +1,51 @@
+import asyncio
+from utils.logger import get_logger
+from modules.retina_perception.prefrontal import local_prefrontal_loop
+from modules.retina_perception.attention import dynamic_attention_loop
+from config import cfg
+
+logger = get_logger("retina_core")
+
+class RetinaPerceptionSystem:
+    def __init__(self):
+        self.tasks = []
+
+    async def start(self, engine, history_manager, default_chat_id: str = str(cfg.TARGET_QQ)):
+        """
+        启动视网膜感知系统的两个核心子循环。
+        """
+        logger.info("[Retina System] Starting Retina Perception System...")
+
+        # 启动前额叶生产者循环
+        # 注意：这里我们让 prefrontal_loop 每次循环读取 dynamic_sleep_interval 的逻辑最好放在内部，
+        # 为了演示，我们将直接启动原始循环。理想情况是修改 prefrontal_loop 从 attention 获取间隔。
+        # 我们会在稍后对 prefrontal.py 进行微调。
+
+        prefrontal_task = asyncio.create_task(
+            local_prefrontal_loop()
+        )
+        self.tasks.append(prefrontal_task)
+
+        # 启动注意力消费者循环
+        attention_task = asyncio.create_task(
+            dynamic_attention_loop(
+                engine=engine,
+                history_manager=history_manager,
+                default_chat_id=default_chat_id
+            )
+        )
+        self.tasks.append(attention_task)
+
+        logger.info("[Retina System] System started successfully.")
+
+    async def stop(self):
+        """
+        停止子循环
+        """
+        logger.info("[Retina System] Stopping Retina Perception System...")
+        for task in self.tasks:
+            task.cancel()
+
+        await asyncio.gather(*self.tasks, return_exceptions=True)
+        self.tasks.clear()
+        logger.info("[Retina System] System stopped.")

--- a/modules/retina_perception/prefrontal.py
+++ b/modules/retina_perception/prefrontal.py
@@ -1,0 +1,164 @@
+import asyncio
+import cv2
+import numpy as np
+from mss import mss
+import time
+from utils.logger import get_logger
+
+try:
+    from rapidocr_onnxruntime import RapidOCR
+    # Initialize OCR engine once (lazy-load or load at startup)
+    ocr_engine = RapidOCR()
+except ImportError:
+    ocr_engine = None
+
+logger = get_logger("retina_prefrontal")
+
+# 全局队列，用于前额叶将处理后的图像推送到注意力循环
+# 队列存放元组：(timestamp, resized_image)
+image_queue = asyncio.Queue(maxsize=3)
+
+
+def capture_and_resize_sync():
+    """
+    同步函数：使用 mss 截取屏幕，保持彩色并缩放到足以看清文字的分辨率。
+    """
+    try:
+        with mss() as sct:
+            monitor = sct.monitors[1]
+            sct_img = sct.grab(monitor)
+            img = np.array(sct_img)
+
+            # 1. 🌟 保留颜色：去掉转灰度图的操作，改为转为标准的 RGB
+            # 颜色对于识别报错（红色）、代码高亮和 UI 元素非常重要
+            img_rgb = cv2.cvtColor(img, cv2.COLOR_BGRA2RGB)
+
+            # 2. 🌟 提高分辨率：不要缩放到 640x480
+            # 建议保持 1280 宽度（720p 级别），这是看清代码文字的底线
+            h, w = img_rgb.shape[:2]
+            target_width = 1280
+            target_height = int(h * (target_width / w))
+
+            img_resized = cv2.resize(img_rgb, (target_width, target_height), interpolation=cv2.INTER_AREA)
+
+            return img_resized
+    except Exception as e:
+        logger.error(f"[Prefrontal] Failed to capture screen: {e}")
+        return None
+
+def compute_mse_sync(img1, img2):
+    """
+    同步函数：计算两张图像的均方误差 (MSE)。
+    MSE 越大，差异越大。
+    """
+    if img1 is None or img2 is None:
+        return 0.0
+    err = np.sum((img1.astype("float") - img2.astype("float")) ** 2)
+    err /= float(img1.shape[0] * img1.shape[1])
+    return err
+
+def extract_ocr_sync(image: np.ndarray) -> str:
+    """
+    同步函数：调用 RapidOCR 提取图片中的文字。
+    """
+    if ocr_engine is None:
+        return "mock_ocr_text_placeholder"
+    try:
+        # RapidOCR requires BGR or RGB array, since we resized grey, let's convert back if needed,
+        # but RapidOCR should handle numpy arrays directly (usually reads better from BGR/RGB).
+        # We'll just pass the image. If it's single channel we might need to convert it.
+        if len(image.shape) == 2:
+            img_bgr = cv2.cvtColor(image, cv2.COLOR_GRAY2BGR)
+        else:
+            img_bgr = image
+
+        result, _ = ocr_engine(img_bgr)
+        if result:
+            # result is a list of tuples: [[points], text, score]
+            texts = [item[1] for item in result]
+            return "\n".join(texts)
+        return ""
+    except Exception as e:
+        logger.error(f"[Prefrontal] OCR extract failed: {e}")
+        return ""
+
+async def ocr_extract(image: np.ndarray) -> str:
+    """
+    异步函数：将 OCR 提取放入线程池防止阻塞
+    """
+    return await asyncio.to_thread(extract_ocr_sync, image)
+
+async def local_prefrontal_loop(interval: float = 60.0, mse_threshold: float = 2000.0, ocr_check_interval: float = 60.0):
+    logger.info("[Prefrontal] Local Prefrontal Cortex loop started.")
+
+    prev_image = None
+    last_ocr_time = time.time()
+    last_ocr_text = ""
+
+    # --- 🌟 新增：静止状态追踪变量 ---
+    static_count = 0
+    current_static_threshold = 20  # 初始阈值：连续 20 次不动触发
+    MAX_STATIC_THRESHOLD = 320     # 阈值上限，防止无限翻倍
+    # ----------------------------------
+
+    while True:
+        try:
+            curr_image = await asyncio.to_thread(capture_and_resize_sync)
+
+            if curr_image is not None:
+                trigger_attention = False
+                is_static_trigger = False  # 新增：标记本次是否为“太久没动”触发
+
+                # 1. 快速感知：画面变化检测
+                if prev_image is not None:
+                    mse = await asyncio.to_thread(compute_mse_sync, prev_image, curr_image)
+                    if mse > mse_threshold:
+                        logger.debug(f"[Prefrontal] MSE threshold exceeded: {mse:.2f}")
+                        trigger_attention = True
+
+                # 2. 定期感知：OCR 变化检测
+                current_time = time.time()
+                if (current_time - last_ocr_time) >= ocr_check_interval:
+                    current_text = await ocr_extract(curr_image)
+                    if current_text != last_ocr_text:
+                        logger.debug(f"[Prefrontal] OCR change detected.")
+                        trigger_attention = True
+                    last_ocr_text = current_text
+                    last_ocr_time = current_time
+
+                # --- 🌟 新增：时间梯度拉长逻辑 ---
+                if trigger_attention:
+                    # 画面有真实变化，清空静止计数，将阈值恢复到敏感状态（20）
+                    static_count = 0
+                    current_static_threshold = 20
+                else:
+                    # 画面毫无变化，开始累加无聊情绪
+                    static_count += 1
+                    if static_count >= current_static_threshold:
+                        logger.info(f"[Prefrontal] 画面已连续静止 {static_count} 次，触发无聊警报！")
+                        trigger_attention = True
+                        is_static_trigger = True
+                        
+                        # 触发后清零计数，并把下一次的阈值翻倍 (时间梯度拉长)
+                        static_count = 0
+                        current_static_threshold = min(current_static_threshold * 2, MAX_STATIC_THRESHOLD)
+                # ----------------------------------
+
+                if trigger_attention:
+                    if image_queue.full():
+                        try:
+                            image_queue.get_nowait()
+                            image_queue.task_done()
+                        except asyncio.QueueEmpty:
+                            pass
+                    # 🌟 修改：将 is_static_trigger 标志一起打包送给下游大脑
+                    await image_queue.put((current_time, curr_image, is_static_trigger))
+
+                prev_image = curr_image
+
+        except Exception as e:
+            logger.error(f"[Prefrontal] Loop exception: {e}")
+
+        import modules.retina_perception.attention as attention_module
+        current_interval = attention_module.dynamic_sleep_interval
+        await asyncio.sleep(current_interval)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,6 @@ opencv-python>=4.8.0
 pyyaml>=6.0
 
 ollama>=0.4.0
+mss>=9.0.0
+plyer>=2.1.0
+rapidocr_onnxruntime>=1.3.16


### PR DESCRIPTION
### Title:
**Refactor: 升级视网膜感知逻辑与情绪驱动的精力系统 (v8.1)**

### 📝 变更概述 (Overview)
本次 PR 主要对 Yuki 的「视网膜感知系统 (Retina Perception)」和「核心精力系统 (Energy Dynamics)」进行了深度重构。核心目标是降低视觉大模型的无意义 API 开销，并通过引入语义防抖、情绪反馈和跨域记忆穿透，大幅提升智能体行为的生物拟真度与交互自然度。

### 🛠️ 核心更新 (Key Changes)

#### 1. 视网膜感知模块优化 (Retina Perception)
* **引入视觉语义防抖 (Semantic Debounce)**：
  在 `attention.py` 中引入 `difflib`，对视觉大模型返回的前后两次画面描述进行相似度计算（阈值 `0.85`）。当画面语义无实质变化时，自动拦截历史注入，并对休眠间隔（`dynamic_sleep_interval`）进行翻倍退避处理，避免产生“失忆金鱼”式的复读。
* **零成本静止状态追踪 (Exponential Backoff for Idle State)**：
  在 `prefrontal.py` 的前额叶循环中增加了画面静止计数器。当屏幕长期无变化时，采取指数梯度拉长策略（触发阈值从 20 递增至 320）。超时触发时，将直接向主系统注入“屏幕长期静止”的潜意识描述，并**完全绕过视觉大模型 API 调用**，极大节省了 Token 开销。
* **物理弹窗接入**：
  遇到重要 Trigger（如致命报错）强制唤醒时，除了在聊天框架内发消息，现已同步接入 `system_alert` 进行桌面物理弹窗警告。

#### 2. 精力与情绪系统升级 (Energy & Emotion)
* **基于词典的情绪驱动反馈**：
  在 `engine.py` 中废弃了单一的机械扣除精力逻辑。通过维护轻量级的正负面词典对当前对话进行极简情绪打分。
  - **正向情绪**：触发多巴胺补偿，恢复 `10` 点精力（受限于上限 `MAX_ENERGY`）。
  - **负向情绪**：触发皮质醇消耗，双倍扣除精力。
* **基于状态的 Prompt 降级 (State-dependent Prompt)**：
  修改了 `build_chat_context`。系统会根据 Yuki 当前的精力值，在系统提示词极简追加 `【状态：精力充沛】` 或 `【状态：有点累了】`。通过最少的 Token 消耗，让底层模型在极度疲惫时自然表现出敷衍和困倦，而在满状态时保持活泼。

#### 3. 跨域记忆穿透 (Cross-Context Injection)
* **潜意识底座与群聊联动**：
  视网膜模块现在默认处于“哑巴监控”状态，所有的视觉观察（无论是否重要）均被悄悄写入机主的私聊上下文中。当在群聊模式（`mode="group"`）中检测到群友提及机主（如包含“哥哥”、“宇健”等关键词）时，`engine` 会主动跨域读取私聊中的最新视觉记录，并以【后台潜意识同步】的形式注入群聊 Prompt。实现了“群聊时爆料机主当前桌面状态”的高级多智能体协同效果。

### 💡 工程收益 (Impact)
1. **成本控制**：拦截了大量无意义的连续视觉 API 请求。
2. **上下文整洁**：解决了 RAG 记忆库和历史记录中被相同画面描述刷屏的问题。
3. **系统拟真**：真正实现了从“被动问答”到“潜意识感知 -> 情绪波动 -> 状态降级”的生物链路闭环。

--- 
**影响范围**：
- `core/engine.py`, `core/brain.py`, `core/prompts.py`
- `modules/retina_perception/attention.py`, `modules/retina_perception/prefrontal.py`


不稳定！！